### PR TITLE
Update the Reggie page

### DIFF
--- a/reggie/index.html
+++ b/reggie/index.html
@@ -33,7 +33,7 @@ layout: reggie
 					<li>Resizable and interactive level overview</li>
 					<li>Location editing</li>
 					<li>Path editing</li>
-					<li>Cross-platform (Windows, Linux, Mac OS X)</li>
+					<li>Cross-platform (Windows, Linux, macOS)</li>
 					<li>Open-source (GNU General Public License v2)</li>
 					<li><a href='/riiv/'>Riivolution loader</a> for custom levels with original discs</li>
 				</ul>
@@ -64,6 +64,10 @@ layout: reggie
 		<td valign='top'>
 			<div class='rheader'><b>Download</b></div>
 			<div class='rcontent'>
+				The latest release for Windows, Ubuntu, and macOS can be found <a href='https://github.com/RoadrunnerWMC/Reggie-Updated/releases'>on this page</a>.
+				<br />
+				Old versions of Reggie (before 2021) are known to have security risks, so using a recent version is strongly recommended.
+				<!-- Switch back to this version once r4 is published:
 				<b>Reggie! release 3 - April 2nd, 2011:</b>
 				<br />
 				<a href='downloads/Reggie_r3_Win32.zip'>Windows</a> (zip)
@@ -71,18 +75,19 @@ layout: reggie
 				<a href='downloads/Reggie_r3.dmg'>Mac OS X</a> (dmg)
 				&middot;
 				<a href='downloads/Reggie_r3_source.zip'>Source/Linux</a> (zip)
+				-->
 				<br />
 				<hr />
-				For help and support, please visit the <a href='/forums/'>RVLution Forums</a> or the #RVLution channel on Badnik IRC (<a 
-href='http://rvlution.net/irc/'>webchat</a>).
+				For help and support, please visit the <a href='https://discord.gg/KNRPfSm'>NSMBW Hacking Depot</a> Discord server.
 				<br />
 				To dump the required files for Reggie! from your game disc, please use the <a href='reggiedumper.zip'>Reggie! Dumper</a> app.
 				<br />
-				GitHub project (for developers): <a href='http://github.com/Treeki/Reggie'>Reggie</a>
+				Current GitHub project (for developers): <a href='https://github.com/RoadrunnerWMC/Reggie-Updated'>Reggie-Updated</a>
 			</div>
 		</td>
 	</tr>
 	
+	<!--
 	<tr>
 		<td valign='top'>
 			<div class='rheader'><b>File Depot</b></div>
@@ -104,6 +109,7 @@ href='http://rvlution.net/irc/'>webchat</a>).
 			</div>
 		</td>
 	</tr>
+	-->
 	
 	<tr>
 		<td colspan='2'>


### PR DESCRIPTION
- Removes download links to Reggie r3 -- which has known security risks -- and replaces them with links to Reggie-Updated, which is the closest currently-maintained alternative currently
- Removes ancient broken help/support links, and replaces them with a link to a current Discord server
- Renames "Mac OS X" to "macOS"